### PR TITLE
Upgrading the mockito library to Mockito 2, which allows us to Mock t…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,7 +30,7 @@ ext {
     anko_version = '0.10.0'
     rxjava_version = '2.1.0'
     retrofit_version = '2.0.2'
-    mockito_version = '1.10.19'
+    mockito_version = '2.8.9'
     spek_version = '1.1.2'
 }
 
@@ -80,6 +80,7 @@ dependencies {
     testCompile "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
     testCompile 'com.nhaarman:mockito-kotlin:1.4.0'
+    testCompile "com.winterbe:expekt:0.5.0"
     testCompile junitJupiter()
 }
 

--- a/app/src/test/java/com/example/kotlin/movieapp/ui/main/MainViewModelSpek.kt
+++ b/app/src/test/java/com/example/kotlin/movieapp/ui/main/MainViewModelSpek.kt
@@ -1,20 +1,32 @@
 package com.example.kotlin.movieapp.ui.main
 
+import com.winterbe.expekt.should
 import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.context
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
 import org.junit.platform.runner.JUnitPlatform
 import org.junit.runner.RunWith
-import kotlin.test.assertEquals
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
 
 @RunWith(JUnitPlatform::class)
 class MainViewModelSpek : Spek ({
-    val viewModel = MainViewModel()
+    //TODO This is not a actual ViewModelSpek. Replace with actual Spek, when real app code is introduced
+    describe("mocking with mockito in spek") {
 
-    context("Testing our hello world") {
+        given("mocking Iterable<T> and Iterator<T>") {
+            val mockedIterable = Mockito.mock(Iterable::class.java)
+            val mockedIterator = Mockito.mock(Iterator::class.java)
+            `when`(mockedIterator.hasNext()).thenReturn(true, true, true, true, false)
+            `when`(mockedIterator.next()).thenReturn(0,1,3,4)
+            `when`(mockedIterable.iterator()).thenReturn(mockedIterator)
+            val actual   = mockedIterable.joinToString(",")
+            val expected = "0,1,3,4"
 
-        it("should have our test strings") {
-            assertEquals(viewModel.firstName, "Kotlin 100")
+            it("should iterate mocked values") {
+                actual.should.be.equal(expected)
+            }
         }
     }
 })

--- a/app/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/app/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ allprojects {
         maven {
             url "https://maven.google.com"
         }
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
     }
 }
 


### PR DESCRIPTION
…he Unmockable ().This is important so we don't have to declare our viewModels as open , just so we can stub it out